### PR TITLE
Kubernetes controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # Raian13_platform
+
 Raian13 Platform repository
 
 ## Homework 1
 
 Развертывание minikube, изучение компонентов Kubernetes
 Создание пода с веб-приложением
+
+## Homework 2
+
+Работа с Replicaset, Deployment и Daemonset

--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  replicas: 3
+  template: 
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: server
+          image: raian13/hipster-frontend:1.1
+          readinessProbe:
+            initialDelaySeconds: 10
+            httpGet:
+              path: "/_healthz"
+              port: 8080
+              httpHeaders:
+              - name: "Cookie"
+                value: "shop_session-id=x-readiness-probe"
+          env:
+          - name: PRODUCT_CATALOG_SERVICE_ADDR
+            value: "product-catalog-service:3550"
+          - name: CURRENCY_SERVICE_ADDR
+            value: "currency-service:7000"
+          - name: CART_SERVICE_ADDR
+            value: "cart-service:7070"
+          - name: RECOMMENDATION_SERVICE_ADDR
+            value: "recommendation-service:8080"
+          - name: CHECKOUT_SERVICE_ADDR
+            value: "checkout-service:5050"
+          - name: SHIPPING_SERVICE_ADDR
+            value: "shipping-service:50051"
+          - name: AD_SERVICE_ADDR
+            value: "ad-service:9555"

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  replicas: 3
+  template: 
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: server
+          image: raian13/hipster-frontend:1.1
+          env:
+          - name: PRODUCT_CATALOG_SERVICE_ADDR
+            value: "product-catalog-service:3550"
+          - name: CURRENCY_SERVICE_ADDR
+            value: "currency-service:7000"
+          - name: CART_SERVICE_ADDR
+            value: "cart-service:7070"
+          - name: RECOMMENDATION_SERVICE_ADDR
+            value: "recommendation-service:8080"
+          - name: CHECKOUT_SERVICE_ADDR
+            value: "checkout-service:5050"
+          - name: SHIPPING_SERVICE_ADDR
+            value: "shipping-service:50051"
+          - name: AD_SERVICE_ADDR
+            value: "ad-service:9555"

--- a/kubernetes-controllers/node-exporter.yaml
+++ b/kubernetes-controllers/node-exporter.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/version: 1.1.1
+  name: node-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: node-exporter
+        app.kubernetes.io/version: 1.1.1
+    spec:
+      containers:
+      - args:
+        - --web.listen-address=127.0.0.1:9100
+        - --path.sysfs=/host/sys
+        - --path.rootfs=/host/root
+        - --no-collector.wifi
+        - --no-collector.hwmon
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
+        - --collector.netclass.ignored-devices=^(veth.*)$
+        - --collector.netdev.device-exclude=^(veth.*)$
+        image: quay.io/prometheus/node-exporter:v1.1.1
+        name: node-exporter
+        resources:
+          limits:
+            cpu: 250m
+            memory: 180Mi
+          requests:
+            cpu: 102m
+            memory: 180Mi
+        volumeMounts:
+        - mountPath: /host/sys
+          mountPropagation: HostToContainer
+          name: sys
+          readOnly: true
+        - mountPath: /host/root
+          mountPropagation: HostToContainer
+          name: root
+          readOnly: true
+      - args:
+        - --logtostderr
+        - --secure-listen-address=[$(IP)]:9100
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --upstream=http://127.0.0.1:9100/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.8.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9100
+          hostPort: 9100
+          name: https
+        resources:
+          limits:
+            cpu: 20m
+            memory: 40Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      volumes:
+      - hostPath:
+          path: /sys
+        name: sys
+      - hostPath:
+          path: /
+        name: root
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+    type: RollingUpdate

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -9,6 +9,13 @@ spec:
     matchLabels:
       app: paymentservice
   replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0
+  minReadySeconds: 60
+  paused: false
   template: 
     metadata:
       labels:
@@ -25,3 +32,4 @@ spec:
           readinessProbe:
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:50051"]
+

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -9,6 +9,11 @@ spec:
     matchLabels:
       app: paymentservice
   replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   template: 
     metadata:
       labels:

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  selector:
+    matchLabels:
+      app: paymentservice
+  replicas: 3
+  template: 
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+        - name: server
+          image: raian13/hipster-paymentservice:1.1

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -22,6 +22,6 @@ spec:
           env:
           - name: PORT
             value: "50051"
-          readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:50051"]
+          # readinessProbe:
+          #   exec:
+          #     command: ["/bin/grpc_health_probe", "-addr=:50051"]

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  selector:
+    matchLabels:
+      app: paymentservice
+  replicas: 3
+  template: 
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+        - name: server
+          image: raian13/hipster-paymentservice:1.0


### PR DESCRIPTION
**Вопрос по frontend replicaset**
Обновление ReplicaSet не ведет к обновлению запущенных подов, потому что ReplicaSetController применяет изменения только к новым подам, но не применяет их к уже запущенным.

**Задания со звездочкой** 
**_blue-green deployment_** - рекомендуется использовать два файла деплоя с разными label + файл сервиса для переключения между деплоями. Но если попытаться сделать в рамках изученного материала - то можно выставить параметр MaxSurge в 100% (позволяет удвоение подов = две версии приложения), параметр maxUnavailable = 0 (сначала новые поды должны непременно стать ready), параметр minReadySeconds = 60 (или 120 или сколько надо) секунд - для создания паузы между успешным созданием новых подов и началом удаления старых. Во время этой паузы мы получаем  деплой с двумя версиями приложения.
**__reverse rolling update__**
Выставляем maxSurge=0 и maxUnavailable=1 - при обновлении сначала терминируется один под, создается один новый, по факту доступности - удаляется следующий старый под, создается еще один новый и т.д.

Обе стратегии у меня заработали ожидаемым образом только при наличии реальной readiness probe

**__node-exporter__**
Запуск подов node-exporter на мастер-нодах реализуется при помощи tolerations. В общем-то, в типовом конфиге daemonset node-exporter, лежащем в инете, по умолчанию настроено так, чтобы запускалось вообще везде (operator: Exists), но я переделала на явное указание запуска на мастер-нодах в соответсвии с примером в доках Kubernetes https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/